### PR TITLE
Add rules for Discord CDN and IP Addresses + case-insensitive

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,10 @@ runs:
               pattern: /(https?:\/\/)?(www\.)?(bit\.ly|t\.co|tinyurl\.com|goo\.gl|ow\.ly|buff\.ly|is\.gd|soo\.gd|t2mio|bl\.ink|clck\.ru|shorte\.st|cutt\.ly|v\.gd|qr\.ae|rb\.gy|rebrand\.ly|tr\.im|shorturl\.at|lnkd\.in)\/[^\s\)]+/g,
               replacement: '[Shortened link removed for safety reasons]'
             },
+            {
+              pattern: /(https?:\/\/)?(\d{1,3}\.){3}\d{1,3}(:\d+)?(\/[^\s\)]*)?/g,
+              replacement: '[IP address link removed for safety reasons]'
+            },
           ];
 
           // Iterate through each regex and replace matches in the comment body

--- a/action.yml
+++ b/action.yml
@@ -21,26 +21,27 @@ runs:
           const regexReplacements = [
             // File sharing websites (general)
             {
-              pattern: /(https?:\/\/)?(www\.)?(box|dropbox|mediafire|sugarsync|tresorit|hightail|opentext|sharefile|citrixsharefile|icloud|onedrive|1drv)\.com\/[^\s\)]+/g,
+              pattern: /(https?:\/\/)?(www\.)?(box|dropbox|mediafire|sugarsync|tresorit|hightail|opentext|sharefile|citrixsharefile|icloud|onedrive|1drv)\.com\/[^\s\)]+/gi,
               replacement: '[Link removed for safety reasons]'
             },
             // Google Drive
             {
-              pattern: /(https?:\/\/)?drive\.google\.com\/[^\s\)]+/g,
+              pattern: /(https?:\/\/)?drive\.google\.com\/[^\s\)]+/gi,
               replacement: '[Link removed for safety reasons]'
             },
             // Discord CDN
             {
-              pattern: /(https?:\/\/)?cdn\.discordapp\.com\/[^\s\)]+/g,
+              pattern: /(https?:\/\/)?cdn\.discordapp\.com\/[^\s\)]+/gi,
               replacement: '[Link removed for safety reasons]'
             },
             // Link shorteners
             {
-              pattern: /(https?:\/\/)?(www\.)?(bit\.ly|t\.co|tinyurl\.com|goo\.gl|ow\.ly|buff\.ly|is\.gd|soo\.gd|t2mio|bl\.ink|clck\.ru|shorte\.st|cutt\.ly|v\.gd|qr\.ae|rb\.gy|rebrand\.ly|tr\.im|shorturl\.at|lnkd\.in)\/[^\s\)]+/g,
+              pattern: /(https?:\/\/)?(www\.)?(bit\.ly|t\.co|tinyurl\.com|goo\.gl|ow\.ly|buff\.ly|is\.gd|soo\.gd|t2mio|bl\.ink|clck\.ru|shorte\.st|cutt\.ly|v\.gd|qr\.ae|rb\.gy|rebrand\.ly|tr\.im|shorturl\.at|lnkd\.in)\/[^\s\)]+/gi,
               replacement: '[Shortened link removed for safety reasons]'
             },
+            // IP addresses
             {
-              pattern: /(https?:\/\/)?(\d{1,3}\.){3}\d{1,3}(:\d+)?(\/[^\s\)]*)?/g,
+              pattern: /(https?:\/\/)?(\d{1,3}\.){3}\d{1,3}(:\d+)?(\/[^\s\)]*)?/gi,
               replacement: '[IP address link removed for safety reasons]'
             },
           ];

--- a/action.yml
+++ b/action.yml
@@ -24,9 +24,14 @@ runs:
               pattern: /(https?:\/\/)?(www\.)?(box|dropbox|mediafire|sugarsync|tresorit|hightail|opentext|sharefile|citrixsharefile|icloud|onedrive|1drv)\.com\/[^\s\)]+/g,
               replacement: '[Link removed for safety reasons]'
             },
-            // Google Drive (needs to match subdomain)
+            // Google Drive
             {
               pattern: /(https?:\/\/)?drive\.google\.com\/[^\s\)]+/g,
+              replacement: '[Link removed for safety reasons]'
+            },
+            // Discord CDN
+            {
+              pattern: /(https?:\/\/)?cdn\.discordapp\.com\/[^\s\)]+/g,
               replacement: '[Link removed for safety reasons]'
             },
             // Link shorteners
@@ -34,7 +39,6 @@ runs:
               pattern: /(https?:\/\/)?(www\.)?(bit\.ly|t\.co|tinyurl\.com|goo\.gl|ow\.ly|buff\.ly|is\.gd|soo\.gd|t2mio|bl\.ink|clck\.ru|shorte\.st|cutt\.ly|v\.gd|qr\.ae|rb\.gy|rebrand\.ly|tr\.im|shorturl\.at|lnkd\.in)\/[^\s\)]+/g,
               replacement: '[Shortened link removed for safety reasons]'
             },
-            // Add more as needed
           ];
 
           // Iterate through each regex and replace matches in the comment body


### PR DESCRIPTION
Changes in this PR:
* Add rule for Discord CDN
* Add rule for IP Addresses (see [discussion](https://github.com/DecimalTurn/Comment-Filter/discussions/5))
* Make patterns case-insensitive

[Demo](https://github.com/DecimalTurn/Comment-Filter-Demo/issues/3)

Discord CDN links mentioned in the wild:
* https://github.com/Azure/azure-cli/issues/29831#issuecomment-2326537380
* https://github.com/orgs/community/discussions/136836#discussioncomment-10532718

