### PR TITLE
Add rule for too many users tagged in comment

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -73,7 +73,7 @@ runs:
 
           // If the comment body was updated, edit the comment
           if (updatedBody === comment.body) {
-            console.log('No suspicious links found.')
+            console.log('No suspicious content found.')
             return
           }
 

--- a/action.yml
+++ b/action.yml
@@ -57,7 +57,7 @@ runs:
             },
             // Multiple tagging of users
             {
-              pattern: /((^|\s)@[a-zA-Z][a-zA-Z]*\s.*){,4}/gi,
+              pattern: /(?:(?:^|\s)@[a-zA-Z][a-zA-Z-]*\b[^@]*){4,}/gims,
               replacement: '[Comment removed because it was tagging too many users]'
             },
           ];

--- a/action.yml
+++ b/action.yml
@@ -55,6 +55,11 @@ runs:
               pattern: /(https?:\/\/)?(\d{1,3}\.){3}\d{1,3}(:\d+)?(\/[^\s\)]*)?/gi,
               replacement: '[IP address link removed for safety reasons]'
             },
+            // Multiple tagging of users
+            {
+              pattern: /((^|\s)@[a-zA-Z][a-zA-Z]*\s.*){,4}/gi,
+              replacement: '[Comment removed because it was tagging too many users]'
+            },
           ];
 
           // Iterate through each regex and replace matches in the comment body

--- a/action.yml
+++ b/action.yml
@@ -90,7 +90,7 @@ runs:
           }
 
           // Extra logging for debugging  
-          //console.log('Updated comment body:', updatedBody);
+          console.log('Updated comment body:\n', updatedBody);
 
           // Edit the comment with the updated body
           await github.rest.issues.updateComment({


### PR DESCRIPTION
If there is 4 users tagged or more in a comment, it will be redacted.

Solves https://github.com/DecimalTurn/Comment-Filter/issues/8