### PR TITLE
Improve matching for rules for tagging of multiple users and IP addresses

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -52,7 +52,7 @@ runs:
             },
             // IP addresses
             {
-              pattern: /(https?:\/\/)?(\d{1,3}\.){3}\d{1,3}(:\d+)?(\/[^\s\)]*)?/gi,
+              pattern: /https?:\/\/(\d{1,3}\.){3}\d{1,3}(:\d+)?(\/[^\s\)]*)?/gi,
               replacement: '[IP address link removed for safety reasons]'
             },
             // Multiple tagging of users

--- a/action.yml
+++ b/action.yml
@@ -57,7 +57,7 @@ runs:
             },
             // Multiple tagging of users
             {
-              pattern: /(?:(?:^|\s)@[a-zA-Z][a-zA-Z-]*\b[^@]*){4,}/gims,
+              pattern: /(?:(?:^|\s|,|;)@[a-zA-Z][a-zA-Z-]*\b[^@]*){4,}/gims,
               replacement: '[Comment removed because it was tagging too many users]'
             },
           ];


### PR DESCRIPTION
2 Minor Fixes:

**Make the protocol mandatory to be detected as a IP Address link.**
Without the protocol, the link is [not clickable](https://github.com/DecimalTurn/Comment-Filter-Demo/issues/3#issuecomment-2727266571) and otherwise it was leading to [false positives](https://github.com/ublue-os/bluefin/issues/1764#issuecomment-2661955842).

**Adding more characters that can appear in front of the first user tag**
This is still not full proof, but it is still an improvement on the previous rule.